### PR TITLE
Implemented Domain-specific Loading of Ontonotes Corpus

### DIFF
--- a/flair/datasets/sequence_labeling.py
+++ b/flair/datasets/sequence_labeling.py
@@ -847,7 +847,7 @@ class ONTONOTES(MultiFileColumnCorpus):
     def get_available_domains(
         cls,
         base_path: Union[str, Path] = None,
-        version: str = "v12",
+        version: str = "v4",
         language: str = "english",
         split: str = "train",
     ) -> List[str]:
@@ -862,7 +862,7 @@ class ONTONOTES(MultiFileColumnCorpus):
         cls,
         processed_data_path: Path,
         split: str = "train",
-        version: str = "v12",
+        version: str = "v4",
         language: str = "english",
         domain: Union[str, List[str], Dict[str, Union[None, str, List[str]]]] = None,
     ) -> Iterable[Path]:


### PR DESCRIPTION
Example Usage:

```python
# Load the complete corpus
corpus = ONTONOTES(in_memory=False)

# Only load data from the broadcast conversation domain
corpus = ONTONOTES(in_memory=False, domain="bc")

# Only load data from the broadcast conversation and news domains
corpus = ONTONOTES(in_memory=False, domain=["bc", "nw"])

# Only load data from specific sources in multiple domains
corpus = ONTONOTES(in_memory=False, domain={"bc": ["cnn", "msnbc"], "nw": "wsj"})
```